### PR TITLE
Fixed background color in the lara-light-teal theme to make the page …

### DIFF
--- a/src/assets/layout/styles/theme/lara-light-teal/theme.css
+++ b/src/assets/layout/styles/theme/lara-light-teal/theme.css
@@ -3525,8 +3525,8 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-pages .p-paginator-page.p-highlight {
-    background: #0f766e;
-    border-color: #0f766e;
+    background: #e5e7eb;
+    border-color: #e5e7eb;
     color: #0f766e;
   }
   .p-paginator .p-paginator-pages .p-paginator-page:not(.p-highlight):hover {


### PR DESCRIPTION
…number visible

The background color of the "lara-light-teal" theme was corrected, which was preventing the page number from being visible.


![image1](https://github.com/primefaces/sakai-ng/assets/74559141/deaaf621-4cd7-4772-a073-2b56ef50efa4)

![image2](https://github.com/primefaces/sakai-ng/assets/74559141/4ae23414-3c7d-4df0-993a-140a43263629)
