### PR TITLE
Fix table row expansion

### DIFF
--- a/src/app/pages/uikit/tabledemo.ts
+++ b/src/app/pages/uikit/tabledemo.ts
@@ -286,7 +286,7 @@ interface expandedRows {
                         </td>
                     </tr>
                 </ng-template>
-                <ng-template #rowexpansion let-product>
+                <ng-template #expandedrow let-product>
                     <tr>
                         <td colspan="7">
                             <div class="p-3">


### PR DESCRIPTION
replace #rowexpansion with #expandedrow in the tabledemo.ts file to be able to expand the row content.

change
`<ng-template #rowexpansion let-product>`

to
`<ng-template #expandedrow let-product>`