### PR TITLE
Fix for depreciated *ngIf and *ngFor

### DIFF
--- a/src/app/layout/component/app.configurator.ts
+++ b/src/app/layout/component/app.configurator.ts
@@ -85,10 +85,14 @@ declare type SurfacesType = {
                 <span class="text-sm text-muted-color font-semibold">Presets</span>
                 <p-selectbutton [options]="presets" [ngModel]="selectedPreset()" (ngModelChange)="onPresetChange($event)" [allowEmpty]="false" size="small" />
             </div>
-            <div *ngIf="showMenuModeButton()" class="flex flex-col gap-2">
-                <span class="text-sm text-muted-color font-semibold">Menu Mode</span>
-                <p-selectbutton [ngModel]="menuMode()" (ngModelChange)="onMenuModeChange($event)" [options]="menuModeOptions" [allowEmpty]="false" size="small" />
-            </div>
+            
+            @if(showMenuModeButton()){
+                <div class="flex flex-col gap-2">
+                    <span class="text-sm text-muted-color font-semibold">Menu Mode</span>
+                    <p-selectbutton [ngModel]="menuMode()" (ngModelChange)="onMenuModeChange($event)" [options]="menuModeOptions" [allowEmpty]="false" size="small" />
+                </div>
+            }
+            
         </div>
     `,
     host: {

--- a/src/app/layout/component/app.menu.ts
+++ b/src/app/layout/component/app.menu.ts
@@ -9,10 +9,13 @@ import { AppMenuitem } from './app.menuitem';
     standalone: true,
     imports: [CommonModule, AppMenuitem, RouterModule],
     template: `<ul class="layout-menu">
-        <ng-container *ngFor="let item of model; let i = index">
-            <li app-menuitem *ngIf="!item.separator" [item]="item" [index]="i" [root]="true"></li>
-            <li *ngIf="item.separator" class="menu-separator"></li>
-        </ng-container>
+        @for(item of model; track $index; let i = $index){
+            @if(item.separator){
+                <li class="menu-separator"></li>
+            }@else{
+                <li app-menuitem [item]="item" [index]="i" [root]="true"></li>
+            }
+        }
     </ul> `
 })
 export class AppMenu {

--- a/src/app/layout/component/app.menuitem.ts
+++ b/src/app/layout/component/app.menuitem.ts
@@ -13,15 +13,21 @@ import { LayoutService } from '../service/layout.service';
     selector: '[app-menuitem]',
     imports: [CommonModule, RouterModule, RippleModule],
     template: `
-        <ng-container>
-            <div *ngIf="root && item.visible !== false" class="layout-menuitem-root-text">{{ item.label }}</div>
-            <a *ngIf="(!item.routerLink || item.items) && item.visible !== false" [attr.href]="item.url" (click)="itemClick($event)" [ngClass]="item.styleClass" [attr.target]="item.target" tabindex="0" pRipple>
+        @if(root && item.visible !== false){
+            <div class="layout-menuitem-root-text">{{ item.label }}</div>
+        }
+        @if((!item.routerLink || item.items) && item.visible !== false){ 
+            <a [attr.href]="item.url" (click)="itemClick($event)" [ngClass]="item.styleClass" [attr.target]="item.target" tabindex="0" pRipple>
                 <i [ngClass]="item.icon" class="layout-menuitem-icon"></i>
                 <span class="layout-menuitem-text">{{ item.label }}</span>
-                <i class="pi pi-fw pi-angle-down layout-submenu-toggler" *ngIf="item.items"></i>
+                @if(item.items){
+                    <i class="pi pi-fw pi-angle-down layout-submenu-toggler"></i>
+                }
             </a>
+        }
+
+        @if(item.routerLink && !item.items && item.visible !== false){
             <a
-                *ngIf="item.routerLink && !item.items && item.visible !== false"
                 (click)="itemClick($event)"
                 [ngClass]="item.styleClass"
                 [routerLink]="item.routerLink"
@@ -40,15 +46,20 @@ import { LayoutService } from '../service/layout.service';
             >
                 <i [ngClass]="item.icon" class="layout-menuitem-icon"></i>
                 <span class="layout-menuitem-text">{{ item.label }}</span>
-                <i class="pi pi-fw pi-angle-down layout-submenu-toggler" *ngIf="item.items"></i>
+                @if(item.items){
+                    <i class="pi pi-fw pi-angle-down layout-submenu-toggler"></i>
+                }
+                
             </a>
+        }
 
-            <ul *ngIf="item.items && item.visible !== false" [@children]="submenuAnimation">
-                <ng-template ngFor let-child let-i="index" [ngForOf]="item.items">
+        @if(item.items && item.visible !== false){
+            <ul [@children]="submenuAnimation">
+                @for(child of item.items; track $index; let i = $index){
                     <li app-menuitem [item]="child" [index]="i" [parentKey]="key" [class]="child['badgeClass']"></li>
-                </ng-template>
+                }
             </ul>
-        </ng-container>
+        }
     `,
     animations: [
         trigger('children', [

--- a/src/app/pages/crud/crud.ts
+++ b/src/app/pages/crud/crud.ts
@@ -149,11 +149,17 @@ interface ExportColumn {
         <p-dialog [(visible)]="productDialog" [style]="{ width: '450px' }" header="Product Details" [modal]="true">
             <ng-template #content>
                 <div class="flex flex-col gap-6">
-                    <img [src]="'https://primefaces.org/cdn/primeng/images/demo/product/' + product.image" [alt]="product.image" class="block m-auto pb-4" *ngIf="product.image" />
+                    @if(product.image){
+                        <img [src]="'https://primefaces.org/cdn/primeng/images/demo/product/' + product.image" [alt]="product.image" class="block m-auto pb-4"/>
+                    }
+                    
                     <div>
                         <label for="name" class="block font-bold mb-3">Name</label>
                         <input type="text" pInputText id="name" [(ngModel)]="product.name" required autofocus fluid />
-                        <small class="text-red-500" *ngIf="submitted && !product.name">Name is required.</small>
+                        @if(submitted && !product.name){
+                            <small class="text-red-500">Name is required.</small>
+                        }
+                        
                     </div>
                     <div>
                         <label for="description" class="block font-bold mb-3">Description</label>

--- a/src/app/pages/uikit/listdemo.ts
+++ b/src/app/pages/uikit/listdemo.ts
@@ -29,7 +29,8 @@ import { Product, ProductService } from '../service/product.service';
 
                 <ng-template #list let-items>
                     <div class="flex flex-col">
-                        <div *ngFor="let item of items; let i = index">
+                        @for(item of items; track $index; let i = $index){
+                        <div>
                             <div class="flex flex-col sm:flex-row sm:items-center p-6 gap-4" [ngClass]="{ 'border-t border-surface': i !== 0 }">
                                 <div class="md:w-40 relative">
                                     <img class="block xl:block mx-auto rounded w-full" src="https://primefaces.org/cdn/primevue/images/product/{{ item.image }}" [alt]="item.name" />
@@ -68,12 +69,14 @@ import { Product, ProductService } from '../service/product.service';
                                 </div>
                             </div>
                         </div>
+                        }
                     </div>
                 </ng-template>
 
                 <ng-template #grid let-items>
                     <div class="grid grid-cols-12 gap-4">
-                        <div *ngFor="let item of items; let i = index" class="col-span-12 sm:col-span-6 lg:col-span-4 p-2">
+                        @for(item of items; track $index; let i = $index){
+                        <div class="col-span-12 sm:col-span-6 lg:col-span-4 p-2">
                             <div class="p-6 border border-surface-200 dark:border-surface-700 bg-surface-0 dark:bg-surface-900 rounded flex flex-col">
                                 <div class="relative w-full shadow-sm">
                                     <img class="rounded w-full" src="https://primefaces.org/cdn/primevue/images/product/{{ item.image }}" [alt]="item.name" />
@@ -120,6 +123,7 @@ import { Product, ProductService } from '../service/product.service';
                                 </div>
                             </div>
                         </div>
+                        }
                     </div>
                 </ng-template>
             </p-dataview>

--- a/src/app/pages/uikit/timelinedemo.ts
+++ b/src/app/pages/uikit/timelinedemo.ts
@@ -63,7 +63,9 @@ import {ButtonModule} from 'primeng/button';
                     </ng-template>
                     <ng-template #content let-event>
                         <p-card [header]="event.status" [subheader]="event.date">
-                            <img *ngIf="event.image" [src]="'/images/product/' + event.image" [alt]="event.name" width="200" class="shadow" />
+                            @if(event.image){
+                                <img [src]="'/images/product/' + event.image" [alt]="event.name" width="200" class="shadow" />
+                            }
                             <p>
                                 Lorem ipsum dolor sit amet, consectetur adipisicing elit. Inventore sed consequuntur error repudiandae numquam deserunt quisquam repellat libero asperiores earum nam nobis, culpa ratione quam perferendis esse,
                                 cupiditate neque quas!

--- a/src/app/pages/uikit/treedemo.ts
+++ b/src/app/pages/uikit/treedemo.ts
@@ -21,20 +21,25 @@ import { NodeService } from '../service/node.service';
             <p-treetable [value]="treeTableValue" [columns]="cols" selectionMode="checkbox" [(selectionKeys)]="selectedTreeTableValue" dataKey="key" [scrollable]="true" [tableStyle]="{ 'min-width': '50rem' }">
                 <ng-template #header let-columns>
                     <tr>
-                        <th *ngFor="let col of columns">
-                            {{ col.header }}
-                        </th>
+                        @for(col of columns; track $index){
+                            <th>{{ col.header }}</th>
+                        }
                     </tr>
                 </ng-template>
                 <ng-template #body let-rowNode let-rowData="rowData" let-columns="columns">
                     <tr [ttRow]="rowNode" [ttSelectableRow]="rowNode">
-                        <td *ngFor="let col of columns; let i = index">
-                            <span class="flex items-center gap-2">
-                                <p-treeTableToggler [rowNode]="rowNode" *ngIf="i === 0" />
-                                <p-treeTableCheckbox [value]="rowNode" *ngIf="i === 0" />
-                                {{ rowData[col.field] }}
-                            </span>
-                        </td>
+                        @for(col of columns; track $index; let i = $index){
+                            <td>
+                                <span class="flex items-center gap-2">
+                                    @if(i === 0){
+                                        <p-treeTableToggler [rowNode]="rowNode"/>
+                                        <p-treeTableCheckbox [value]="rowNode"/>
+                                    }
+                                    {{ rowData[col.field] }}
+                                </span>
+                            </td>
+                        }
+                        
                     </tr>
                 </ng-template>
             </p-treetable>


### PR DESCRIPTION
The *ngIf and *ngFor block used are depreciated from Angular version 17 and are planned to be completely removed in version 22, this change safely migrates those blocks to newly supported @if and @for blocks.